### PR TITLE
when dropping privileges, change ownership of socket file

### DIFF
--- a/neverbleed.h
+++ b/neverbleed.h
@@ -35,6 +35,7 @@ extern "C" {
 
 typedef struct st_neverbleed_t {
     ENGINE *engine;
+    pid_t daemon_pid;
     struct sockaddr_un sun_;
     pthread_key_t thread_key;
     unsigned char auth_token[NEVERBLEED_AUTH_TOKEN_SIZE];
@@ -49,9 +50,9 @@ int neverbleed_init(neverbleed_t *nb, char *errbuf);
  */
 int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ctx, const char *fn, char *errbuf);
 /**
- * setuidgid
+ * setuidgid (also changes the file permissions so that `user` can connect to the daemon, if change_socket_ownership is non-zero)
  */
-int neverbleed_setuidgid(neverbleed_t *nb, const char *user);
+int neverbleed_setuidgid(neverbleed_t *nb, const char *user, int change_socket_ownership);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds an extra argument to `neverbleed_setuidgid` indicating whether to change the ownership of the socket file (and the temporary directory containing the file) to the specified user, so that:
- client processes running under the privilege of the specified user can connect to the daemon
- daemon can remove the socket file and the directory when it shuts down
