### PR TITLE
add support for removal of private keys

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -451,7 +451,6 @@ static size_t daemon_set_rsa(RSA *rsa)
     BITUNSET(daemon_vars.keys.bita_keys, index);
 
     daemon_vars.keys.size++;
-    assert(daemon_vars.keys.keys[index] == NULL);
     daemon_vars.keys.keys[index] = rsa;
     RSA_up_ref(rsa);
     pthread_mutex_unlock(&daemon_vars.keys.lock);
@@ -844,7 +843,7 @@ static EVP_PKEY *ecdsa_create_pkey(neverbleed_t *nb, size_t key_index, int curve
     return pkey;
 }
 
-int neverbleed_del_ecdsa_key(neverbleed_t *nb, const uint32_t key_index)
+int neverbleed_del_ecdsa_key(neverbleed_t *nb, const size_t key_index)
 {
     struct st_neverbleed_thread_data_t *thdata = get_thread_data(nb);
     struct expbuf_t buf = {NULL};
@@ -1180,7 +1179,7 @@ Redo:
     _exit(0);
 }
 
-int neverbleed_del_rsa_key(neverbleed_t *nb, const uint32_t key_index)
+int neverbleed_del_rsa_key(neverbleed_t *nb, const size_t key_index)
 {
     struct st_neverbleed_thread_data_t *thdata = get_thread_data(nb);
     struct expbuf_t buf = {NULL};

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -422,11 +422,23 @@ static size_t bita_ffirst(const uint8_t *b, const size_t tot, size_t bits)
     return bita_ffirst(&b[8], tot, bits + 64);
 }
 
+/*
+ * bit operation helpers for the bit-array in key_slots
+ */
+#define BITMASK(b) (1 << ((b) % CHAR_BIT))
+#define BITBYTE(b) ((b) / CHAR_BIT)
+#define BITSET(a, b) ((a)[BITBYTE(b)] |= BITMASK(b))
+#define BITUNSET(a, b) ((a)[BITBYTE(b)] &= ~BITMASK(b))
+#define BITBYTES(nb) ((nb + CHAR_BIT - 1) / CHAR_BIT)
+#define BITCHECK(a, b) ((a)[BITBYTE(b)] & BITMASK(b))
+
 static void adjust_slots_reserved_size(int type, struct key_slots *slots)
 {
+#define ROUND2WORD(n) (n + 64 - 1 - (n + 64 - 1) % 64)
     if (!slots->reserved_size || (slots->size >= slots->reserved_size)) {
         size_t size = slots->reserved_size ? ROUND2WORD((size_t)(slots->reserved_size * 0.50) + slots->reserved_size)
                 : default_reserved_size;
+#undef ROUND2WORD
 
         switch (type) {
         case NEVERBLEED_TYPE_RSA:

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -877,7 +877,7 @@ static int del_ecdsa_key_stub(struct expbuf_t *buf)
         return -1;
     }
 
-    if (!daemon_vars.keys.keys || key_index >= daemon_vars.keys.ecdsa_size) {
+    if (!daemon_vars.keys.keys || key_index >= daemon_vars.keys.reserved_ecdsa_size) {
         errno = 0;
         warnf("%s: invalid key index %zu", __FUNCTION__, key_index);
         goto respond;
@@ -1214,7 +1214,7 @@ static int del_rsa_key_stub(struct expbuf_t *buf)
         return -1;
     }
 
-    if (!daemon_vars.keys.keys || key_index >= daemon_vars.keys.size) {
+    if (!daemon_vars.keys.keys || key_index >= daemon_vars.keys.reserved_size) {
         errno = 0;
         warnf("%s: invalid key index %zu", __FUNCTION__, key_index);
         goto respond;
@@ -1228,8 +1228,8 @@ static int del_rsa_key_stub(struct expbuf_t *buf)
     pthread_mutex_lock(&daemon_vars.keys.lock);
     BITSET(daemon_vars.keys.bita_keys, key_index);
     daemon_vars.keys.size--;
-    daemon_vars.keys.keys[key_index] = NULL;
     RSA_free(daemon_vars.keys.keys[key_index]);
+    daemon_vars.keys.keys[key_index] = NULL;
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
     ret = 1;

--- a/neverbleed.h
+++ b/neverbleed.h
@@ -56,19 +56,7 @@ int neverbleed_init(neverbleed_t *nb, char *errbuf);
 /**
  * loads a private key file (returns 1 if successful)
  */
-int neverbleed_load_private_key_file_index(neverbleed_t *nb, SSL_CTX *ctx, const char *fn, char *errbuf, size_t *key_index, size_t *type);
-static inline int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ctx, const char *fn, char *errbuf) {
-    return neverbleed_load_private_key_file_index(nb, ctx, fn, errbuf, NULL, NULL);
-}
-
-/*
- * deletes a private key at key index position (returns 1 if successful)
- */
-int neverbleed_del_rsa_key(neverbleed_t *nb, const size_t key_index);
-#if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL)
-int neverbleed_del_ecdsa_key(neverbleed_t *nb, const size_t key_index);
-#endif
-
+int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ctx, const char *fn, char *errbuf);
 /**
  * setuidgid (also changes the file permissions so that `user` can connect to the daemon, if change_socket_ownership is non-zero)
  */

--- a/neverbleed.h
+++ b/neverbleed.h
@@ -64,9 +64,9 @@ static inline int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ct
 /*
  * deletes a private key at key index position (returns 1 if successful)
  */
-int neverbleed_del_rsa_key(neverbleed_t *nb, const uint32_t key_index);
+int neverbleed_del_rsa_key(neverbleed_t *nb, const size_t key_index);
 #if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL)
-int neverbleed_del_ecdsa_key(neverbleed_t *nb, const uint32_t key_index);
+int neverbleed_del_ecdsa_key(neverbleed_t *nb, const size_t key_index);
 #endif
 
 /**

--- a/neverbleed.h
+++ b/neverbleed.h
@@ -41,14 +41,6 @@ typedef struct st_neverbleed_t {
     unsigned char auth_token[NEVERBLEED_AUTH_TOKEN_SIZE];
 } neverbleed_t;
 
-#define ROUND2WORD(n) (n + 64 - 1 - (n + 64 - 1) % 64)
-#define BITMASK(b) (1 << ((b) % CHAR_BIT))
-#define BITBYTE(b) ((b) / CHAR_BIT)
-#define BITSET(a, b) ((a)[BITBYTE(b)] |= BITMASK(b))
-#define BITUNSET(a, b) ((a)[BITBYTE(b)] &= ~BITMASK(b))
-#define BITBYTES(nb) ((nb + CHAR_BIT - 1) / CHAR_BIT)
-#define BITCHECK(a, b) ((a)[BITBYTE(b)] & BITMASK(b))
-
 /**
  * initializes the privilege separation engine (returns 0 if successful)
  */


### PR DESCRIPTION
hi 👋 
here's the PR we've discussed earlier: well, the initial cut that adds removal of private keys.

New functions: neverbleed_del_rsa_key(), neverbleed_del_ecdsa_key(), and neverbleed_load_private_key_file_index().
Use a bitarray impl to quickly find gaps in either key array - could go for a union of a common (key) type but then with a larger changeset.

This PR also changes the allocation of the key arrays to chunks rounded up to wordsize. This may be important when many keys are inserted quickly (which happens to be our use case). The rounding up to wordsize is mostly important (makes it simpler) for the bitarray check (no need to mask off remaining bytes). Does this make sense?

neverbleed_load_private_key_file_index() in particular looks odd... perhaps it could return the key type, which would make it different from neverbleed_load_private_key_file() function, which expects 0 or 1 returns.

Considering this PR, it has passed only the most rudimentary tests: like a few loads and mid-array removals.

Planning on adding a stress tester which would add and remove thousands of keys measuring performance and perhaps finding issues along the way.

Also, not sure whether the del() functions should return an errbuf reponse like the load stub func. 

please let me know what you think. Thank you! 

cheers 🍺 
