### PR TITLE
Some cleanups 

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -36,6 +36,15 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
+
+#include <openssl/opensslv.h>
+
+#if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL)
+#define OPENSSL_1_1_API 1
+#else
+#define OPENSSL_1_1_API 0
+#endif
+
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 #include <openssl/rsa.h>
@@ -45,11 +54,6 @@
 #endif
 #include "neverbleed.h"
 
-#if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL)
-#define OPENSSL_1_1_API 1
-#else
-#define OPENSSL_1_1_API 0
-#endif
 
 enum neverbleed_type { NEVERBLEED_TYPE_ERROR, NEVERBLEED_TYPE_RSA, NEVERBLEED_TYPE_ECDSA };
 

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -48,7 +48,6 @@
 #define NEVERBLEED_OPAQUE_RSA_METHOD
 #endif
 
-/* LibreSSL lacks OPENSSL_NO_EC even if the EC APIs are not provided. */
 #if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(OPENSSL_NO_EC) \
     && (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x2090100fL)
 /* EC_KEY_METHOD and related APIs are avaliable, so ECDSA is enabled. */

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -32,6 +32,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/uio.h>
@@ -54,17 +57,14 @@
 #define OPENSSL_EC_API 0
 #endif
 
-#include <openssl/rand.h>
-#include <openssl/ssl.h>
-#include <openssl/rsa.h>
 #include <openssl/bn.h>
 #if OPENSSL_EC_API
 #include <openssl/ec.h>
 #endif
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
+#include <openssl/ssl.h>
 
-#ifdef __linux__
-#include <sys/prctl.h>
-#endif
 #include "neverbleed.h"
 
 enum neverbleed_type { NEVERBLEED_TYPE_ERROR, NEVERBLEED_TYPE_RSA, NEVERBLEED_TYPE_ECDSA };

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -43,7 +43,7 @@
 #include <openssl/opensslconf.h>
 #include <openssl/opensslv.h>
 
-#if (!defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x1010000fL)
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)
 #define OPENSSL_1_1_API 1
 #else
 #define OPENSSL_1_1_API 0
@@ -65,7 +65,8 @@
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
 
-#if !OPENSSL_1_1_API && (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER < 0x2070000fL)
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL \
+    || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 
 static void RSA_get0_key(const RSA *rsa, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
 {

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1083,7 +1083,7 @@ static int load_key_stub(struct expbuf_t *buf)
         ec_pubkeystr = BN_bn2hex(ec_pubkeybn);
         break;
 #else
-        snprintf(errbuf, sizeof(errbuf), "ECDSA support requires OpenSSL >= 1.1.0");
+        snprintf(errbuf, sizeof(errbuf), "ECDSA support requires OpenSSL >= 1.1.0 or LibreSSL >= 2.9.1");
         goto Respond;
 #endif
     }

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1421,16 +1421,16 @@ int neverbleed_init(neverbleed_t *nb, char *errbuf)
 {
     int pipe_fds[2] = {-1, -1}, listen_fd = -1;
     char *tempdir = NULL;
-    const RSA_METHOD *default_method;
+    const RSA_METHOD *rsa_default_method;
     RSA_METHOD *rsa_method;
 #ifdef NEVERBLEED_ECDSA
-    EC_KEY_METHOD *ecdsa_method;
     const EC_KEY_METHOD *ecdsa_default_method;
+    EC_KEY_METHOD *ecdsa_method;
 #endif
 
 #ifdef NEVERBLEED_OPAQUE_RSA_METHOD
-    default_method = RSA_PKCS1_OpenSSL();
-    rsa_method = RSA_meth_dup(default_method);
+    rsa_default_method = RSA_PKCS1_OpenSSL();
+    rsa_method = RSA_meth_dup(rsa_default_method);
 
     RSA_meth_set1_name(rsa_method, "privsep RSA method");
     RSA_meth_set_priv_enc(rsa_method, priv_enc_proxy);
@@ -1438,13 +1438,13 @@ int neverbleed_init(neverbleed_t *nb, char *errbuf)
     RSA_meth_set_sign(rsa_method, sign_proxy);
     RSA_meth_set_finish(rsa_method, priv_rsa_finish);
 #else
-    default_method = RSA_PKCS1_SSLeay();
+    rsa_default_method = RSA_PKCS1_SSLeay();
     rsa_method = &static_rsa_method;
 
-    rsa_method->rsa_pub_enc = default_method->rsa_pub_enc;
-    rsa_method->rsa_pub_dec = default_method->rsa_pub_dec;
-    rsa_method->rsa_verify = default_method->rsa_verify;
-    rsa_method->bn_mod_exp = default_method->bn_mod_exp;
+    rsa_method->rsa_pub_enc = rsa_default_method->rsa_pub_enc;
+    rsa_method->rsa_pub_dec = rsa_default_method->rsa_pub_dec;
+    rsa_method->rsa_verify = rsa_default_method->rsa_verify;
+    rsa_method->bn_mod_exp = rsa_default_method->bn_mod_exp;
 #endif
 
 #ifdef NEVERBLEED_ECDSA

--- a/test.c
+++ b/test.c
@@ -25,8 +25,11 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <openssl/crypto.h>
+
+#include <openssl/ec.h>
+#include <openssl/evp.h>
 #include <openssl/ssl.h>
+
 #include "neverbleed.h"
 
 static void setup_ecc_key(SSL_CTX *ssl_ctx)
@@ -100,6 +103,7 @@ int main(int argc, char **argv)
     int use_privsep;
 
     /* initialization */
+    /* FIXME: These APIs are deprecated in favor of OPENSSL_init_crypto in 1.1.0. */
     SSL_load_error_strings();
     SSL_library_init();
     OpenSSL_add_all_algorithms();

--- a/test.c
+++ b/test.c
@@ -26,12 +26,23 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <openssl/opensslconf.h>
+#include <openssl/opensslv.h>
+
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(OPENSSL_NO_EC) \
+    && (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x2090100fL)
+#define NEVERBLEED_TEST_ECDSA
+#endif
+
+#ifdef NEVERBLEED_TEST_ECDSA
 #include <openssl/ec.h>
+#endif
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
 
 #include "neverbleed.h"
 
+#ifdef NEVERBLEED_TEST_ECDSA
 static void setup_ecc_key(SSL_CTX *ssl_ctx)
 {
     int nid = NID_X9_62_prime256v1;
@@ -43,6 +54,7 @@ static void setup_ecc_key(SSL_CTX *ssl_ctx)
     SSL_CTX_set_tmp_ecdh(ssl_ctx, key);
     EC_KEY_free(key);
 }
+#endif
 
 int dumb_https_server(unsigned short port, SSL_CTX *ctx)
 {
@@ -113,7 +125,9 @@ int main(int argc, char **argv)
     }
     ctx = SSL_CTX_new(SSLv23_server_method());
     SSL_CTX_set_options(ctx, SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
+#ifdef NEVERBLEED_TEST_ECDSA
     setup_ecc_key(ctx);
+#endif
 
     /* parse args */
     if (argc != 5) {


### PR DESCRIPTION
Besides trivial "add one blank line here for consistency" and "the ordering seems dirty a bit" ones, this PR does the following:

1. Check if EC APIs are available or not, instead of assuming that OpenSSL 1.1.0 or later is always fine.
2. Use `NEVERBLEED_` prefix for feature detection macros to avoid future collisions.
3. Do not rely on indirect `#include`s

I believe these changes will improve maintainability and compatibility with LibreSSL. However, the branch is constructed on a step-by-step basis, so please feel free to point out inappropriate ones. I am ready to exclude them.

Compiles with:
- [x] OpenSSL 1.1.1 (opaque RSA_METHOD, EC APIs available, `RSA_` shim unneeded)
- [x] OpenSSL 1.1.0k (opaque RSA_METHOD, EC APIs available, `RSA_` shim unneeded)
- [x] OpenSSL 1.1.0k (opaque RSA_METHOD, EC APIs unavailable, `RSA_` shim unneeded)
- [x] OpenSSL 1.0.2k (not opaque RSA_METHOD, EC APIs unavaliable, `RSA_` shim needed)
- [x] LibreSSL 2.9.1 (not opaque RSA_METHOD, EC APIs available, `RSA_` shim unneeded)
- [x] LibreSSL 2.8.3 (not opaque RSA_METHOD, EC APIs unavailable, `RSA_` shim unneeded)
- [x] LibreSSL 2.6.5 (not opaque RSA_METHOD, EC APIs unavailable, `RSA_` shim needed)

Fixes https://github.com/h2o/neverbleed/issues/19