### PR TITLE
Finish memory leak

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1229,12 +1229,20 @@ Redo:
     _exit(0);
 }
 
+#ifdef NEVERBLEED_OPAQUE_RSA_METHOD
+static int (*rsa_finish)(RSA *rsa);
+#endif
+
 static int priv_rsa_finish(RSA *rsa)
 {
     struct st_neverbleed_rsa_exdata_t *exdata;
     struct st_neverbleed_thread_data_t *thdata;
 
     get_privsep_data(rsa, &exdata, &thdata);
+
+#ifdef NEVERBLEED_OPAQUE_RSA_METHOD
+    rsa_finish(rsa);
+#endif
 
     struct expbuf_t buf = {NULL};
     size_t ret;
@@ -1431,6 +1439,7 @@ int neverbleed_init(neverbleed_t *nb, char *errbuf)
 #ifdef NEVERBLEED_OPAQUE_RSA_METHOD
     rsa_default_method = RSA_PKCS1_OpenSSL();
     rsa_method = RSA_meth_dup(rsa_default_method);
+    rsa_finish = RSA_meth_get_finish(rsa_method);
 
     RSA_meth_set1_name(rsa_method, "privsep RSA method");
     RSA_meth_set_priv_enc(rsa_method, priv_enc_proxy);


### PR DESCRIPTION
As reported in #26.

Differences from https://github.com/tatsuhiro-t/neverbleed/commit/003de52b35add6a9ff157d06b0f9ffda8586df34 are:
* NULL check of `exdata` has been omitted, as that is checked within `get_privsep_data`
* all use of `rsa_finish` has been surrounded by `NEVERBLEED_OPAQUE_RSA_METHOD`

@omasanori Would you mind reviewing this PR?