### PR TITLE
Implement closefrom(2) where available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+CC?=    cc
+CFLAGS+=    -Wall -fsanitize=address -fstack-protector -g
+TARGET= neverbleed
+OBJS=   test.o neverbleed.o
+PREFIX?=    /usr/local
+
+LIBS=   -lpthread -lssl -lcrypto
+
+all:    $(TARGET)
+
+.c.o:
+	$(CC) $(CFLAGS) -c $<
+
+neverbleed:	$(OBJS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBS)
+
+clean:
+	rm -fr *.o $(TARGET)

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1367,21 +1367,50 @@ Exit:
     return NULL;
 }
 
+static void cleanup_fds(int listen_fd, int close_notify_fd)
+{
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    int maxfd, k;
+
+    maxfd = 0;
+    if (listen_fd > maxfd) {
+        maxfd = listen_fd;
+    }
+    if (close_notify_fd > maxfd) {
+        maxfd = close_notify_fd;
+    }
+    for (k = 0; k < maxfd; k++) {
+        if (k == listen_fd || k == close_notify_fd)
+                continue;
+        switch (k) {
+        case STDOUT_FILENO:
+        case STDERR_FILENO:
+        case STDIN_FILENO:
+            break;
+        default:
+            (void) close(k);
+        }
+    }
+    closefrom(maxfd + 1);
+#else
+    int fd;
+
+    fd = (int)sysconf(_SC_OPEN_MAX) - 1;
+    for (; fd > 2; --fd) {
+        if (fd == listen_fd || fd == close_notify_fd)
+                continue;
+        close(fd);
+    }
+#endif
+}
+
 __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notify_fd, const char *tempdir)
 {
     pthread_t tid;
     pthread_attr_t thattr;
     int sock_fd;
 
-    { /* close all descriptors (except STDIN, STDOUT, STRERR, listen_fd, close_notify_fd) */
-        int fd = (int)sysconf(_SC_OPEN_MAX) - 1;
-        for (; fd > 2; --fd) {
-            if (fd == listen_fd || fd == close_notify_fd)
-                continue;
-            close(fd);
-        }
-    }
-
+    cleanup_fds(listen_fd, close_notify_fd);
     pthread_attr_init(&thattr);
     pthread_attr_setdetachstate(&thattr, 1);
 


### PR DESCRIPTION
Currently, when the neverbleed process is forked we query _SC_OPEN_MAX and
iterate through every file descriptor above STDERR (skipping listen and
close notify file descriptors) and call the close(2) syscall on the fd.
Each syscall is a context switch, and depending on the audit/debug state of
the system during this time, roughly 231,000 syscalls will be executed.
On security audited, traced or otherwise hooked (kprobes, ebpf, perf)
processes, this will generate 231,000 records being committed to disk.

This change introduces an optimization which determines the highest file
descriptor value currently in the process, uses the standard close(2) syscall
for anything less than (excluding stdout, stderr, and stdin) then executes
closefrom(2) on the highest fd plus one. This substantially decreases the number
of context switches during the bootstrap phase of the neverbleed process (from
231,000 to roughly 9. This change also includes the necessary cmake changes to
detect the functionality. Tested and verified on FreeBSD:

```
 [..]
 52544: close(3)                                  = 0 (0x0)
 52544: close(4)                                  = 0 (0x0)
 52544: close(5)                                  = 0 (0x0)
 52544: close(6)                                  = 0 (0x0)
 52544: close(7)                                  = 0 (0x0)
 52544: close(8)                                  = 0 (0x0)
 52544: close(9)                                  = 0 (0x0)
 52544: close(11)                                 ERR#9 'Bad file descriptor'
 52544: closefrom(13)                             = 0 (0x0)
 [..]
```
Requested by: @kazuho
Original PR: https://github.com/h2o/h2o/pull/2332