### PR TITLE
fix: start offset calculation in expbuf_reserve

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -231,7 +231,7 @@ static void expbuf_reserve(struct expbuf_t *buf, size_t extra)
         buf->capacity *= 2;
     if ((n = realloc(buf->buf, buf->capacity)) == NULL)
         dief("realloc failed");
-    buf->start = n + (buf->start - buf->end);
+    buf->start = n + (buf->start - buf->buf);
     buf->end = n + (buf->end - buf->buf);
     buf->buf = n;
 }


### PR DESCRIPTION
if there's data in the expbuf and we realloc this offset ends up being negative and buf->start points out-of-bounds