### PR TITLE
add high-level API that wraps EVP_DigestSign in async

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -110,6 +110,8 @@ static void RSA_set_flags(RSA *r, int flags)
     r->flags |= flags;
 }
 
+#define EVP_PKEY_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_EVP_PKEY)
+
 #endif
 
 #include "neverbleed.h"
@@ -474,120 +476,61 @@ static void get_privsep_data(const RSA *rsa, struct st_neverbleed_rsa_exdata_t *
     *thdata = get_thread_data((*exdata)->nb);
 }
 
-static const size_t default_reserved_size = 8192;
-
-struct key_slots {
-    size_t size;
-    size_t reserved_size;
-    /* bit array slots:
-     *   1-bit slot available
-     *   0-bit slot unavailable
-     */
-    uint8_t *bita_avail;
-};
-
 static struct {
     struct {
         pthread_mutex_t lock;
-        RSA **keys;
-        struct key_slots rsa_slots;
-        EC_KEY **ecdsa_keys;
-        struct key_slots ecdsa_slots;
+        struct {
+            EVP_PKEY *pkey;
+            /**
+             * if the slot is currently empty, contains the index of the next empty slot, or SIZE_MAX if there is no more
+             */
+            size_t next_empty;
+        } *slots;
+        size_t num_slots;
+        size_t first_empty;
     } keys;
     neverbleed_t *nb;
-} daemon_vars = {{PTHREAD_MUTEX_INITIALIZER}};
+} daemon_vars = {{.lock = PTHREAD_MUTEX_INITIALIZER, .first_empty = SIZE_MAX}};
 
 static RSA *daemon_get_rsa(size_t key_index)
 {
-    RSA *rsa;
+    RSA *rsa = NULL;
 
     pthread_mutex_lock(&daemon_vars.keys.lock);
-    rsa = daemon_vars.keys.keys[key_index];
-    if (rsa)
-        RSA_up_ref(rsa);
+    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL)
+        rsa = EVP_PKEY_get1_RSA(daemon_vars.keys.slots[key_index].pkey);
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
     return rsa;
 }
 
-/*
- *  Returns an available slot in bit array B
- *  or if not found, returns SIZE_MAX
- */
-static size_t bita_ffirst(const uint8_t *b, const size_t tot, size_t bits)
+size_t allocate_slot(void)
 {
-    if (bits >= tot)
-        return SIZE_MAX;
+    size_t index;
 
-    uint64_t w = *((uint64_t *) b);
-    /* __builtin_ffsll returns one plus the index of the least significant 1-bit, or zero if not found */
-    uint32_t r = __builtin_ffsll(w);
-    if (r)
-        return bits + r - 1; /* adjust result */
-
-    return bita_ffirst(&b[8], tot, bits + 64);
-}
-
-/*
- * bit operation helpers for the bit-array in key_slots
- */
-#define BITMASK(b) (1 << ((b) % CHAR_BIT))
-#define BITBYTE(b) ((b) / CHAR_BIT)
-#define BITSET(a, b) ((a)[BITBYTE(b)] |= BITMASK(b))
-#define BITUNSET(a, b) ((a)[BITBYTE(b)] &= ~BITMASK(b))
-#define BITBYTES(nb) ((nb + CHAR_BIT - 1) / CHAR_BIT)
-#define BITCHECK(a, b) ((a)[BITBYTE(b)] & BITMASK(b))
-
-static void adjust_slots_reserved_size(int type, struct key_slots *slots)
-{
-#define ROUND2WORD(n) (n + 64 - 1 - (n + 64 - 1) % 64)
-    if (!slots->reserved_size || (slots->size >= slots->reserved_size)) {
-        size_t size = slots->reserved_size ? ROUND2WORD((size_t)(slots->reserved_size * 0.50) + slots->reserved_size)
-                : default_reserved_size;
-#undef ROUND2WORD
-
-        switch (type) {
-        case NEVERBLEED_TYPE_RSA:
-            if ((daemon_vars.keys.keys = realloc(daemon_vars.keys.keys, sizeof(*daemon_vars.keys.keys) * size)) == NULL)
-                dief("no memory");
-            break;
-        case NEVERBLEED_TYPE_ECDSA:
-            if ((daemon_vars.keys.ecdsa_keys = realloc(daemon_vars.keys.ecdsa_keys, sizeof(*daemon_vars.keys.ecdsa_keys) * size)) == NULL)
-                dief("no memory");
-            break;
-        default:
-            dief("invalid type adjusting reserved");
-        }
-
-        uint8_t *b;
-        if ((b = realloc(slots->bita_avail, BITBYTES(size))) == NULL)
+    if ((index = daemon_vars.keys.first_empty) != SIZE_MAX) {
+        daemon_vars.keys.first_empty = daemon_vars.keys.slots[index].next_empty;
+    } else {
+        if ((daemon_vars.keys.slots = realloc(daemon_vars.keys.slots,
+                                              sizeof(daemon_vars.keys.slots[0]) * (daemon_vars.keys.num_slots + 1))) == NULL)
             dief("no memory");
-
-        /* set all bits to 1 making all slots available */
-        memset(&b[BITBYTES(slots->reserved_size)], 0xff, BITBYTES(size - slots->reserved_size));
-
-        slots->bita_avail = b;
-        slots->reserved_size = size;
+        index = daemon_vars.keys.num_slots++;
     }
+
+    daemon_vars.keys.slots[index].pkey = NULL;
+    daemon_vars.keys.slots[index].next_empty = SIZE_MAX;
+
+    return index;
 }
 
-static size_t daemon_set_rsa(RSA *rsa)
+static size_t daemon_set_pkey(EVP_PKEY *pkey)
 {
     pthread_mutex_lock(&daemon_vars.keys.lock);
 
-    adjust_slots_reserved_size(NEVERBLEED_TYPE_RSA, &daemon_vars.keys.rsa_slots);
+    size_t index = allocate_slot();
+    daemon_vars.keys.slots[index].pkey = pkey;
+    EVP_PKEY_up_ref(pkey);
 
-    size_t index = bita_ffirst(daemon_vars.keys.rsa_slots.bita_avail, daemon_vars.keys.rsa_slots.reserved_size, 0);
-
-    if (index == SIZE_MAX)
-        dief("no available slot for key");
-
-    /* set slot as unavailable */
-    BITUNSET(daemon_vars.keys.rsa_slots.bita_avail, index);
-
-    daemon_vars.keys.rsa_slots.size++;
-    daemon_vars.keys.keys[index] = rsa;
-    RSA_up_ref(rsa);
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
     return index;
@@ -768,37 +711,14 @@ static EVP_PKEY *create_pkey(neverbleed_t *nb, size_t key_index, const char *ebu
 
 static EC_KEY *daemon_get_ecdsa(size_t key_index)
 {
-    EC_KEY *ec_key;
+    EC_KEY *ec_key = NULL;
 
     pthread_mutex_lock(&daemon_vars.keys.lock);
-    ec_key = daemon_vars.keys.ecdsa_keys[key_index];
-    if (ec_key)
-        EC_KEY_up_ref(ec_key);
+    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL)
+        ec_key = EVP_PKEY_get1_EC_KEY(daemon_vars.keys.slots[key_index].pkey);
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
     return ec_key;
-}
-
-static size_t daemon_set_ecdsa(EC_KEY *ec_key)
-{
-    pthread_mutex_lock(&daemon_vars.keys.lock);
-
-    adjust_slots_reserved_size(NEVERBLEED_TYPE_ECDSA, &daemon_vars.keys.ecdsa_slots);
-
-    size_t index = bita_ffirst(daemon_vars.keys.ecdsa_slots.bita_avail, daemon_vars.keys.ecdsa_slots.reserved_size, 0);
-
-    if (index == SIZE_MAX)
-        dief("no available slot for key");
-
-    /* set slot as unavailable */
-    BITUNSET(daemon_vars.keys.ecdsa_slots.bita_avail, index);
-
-    daemon_vars.keys.ecdsa_slots.size++;
-    daemon_vars.keys.ecdsa_keys[index] = ec_key;
-    EC_KEY_up_ref(ec_key);
-    pthread_mutex_unlock(&daemon_vars.keys.lock);
-
-    return index;
 }
 
 static int ecdsa_sign_stub(neverbleed_iobuf_t *buf)
@@ -939,7 +859,7 @@ static void priv_ecdsa_finish(EC_KEY *key)
     neverbleed_iobuf_t buf = {NULL};
     size_t ret;
 
-    iobuf_push_str(&buf, "del_ecdsa_key");
+    iobuf_push_str(&buf, "del_pkey");
     iobuf_push_num(&buf, exdata->key_index);
     iobuf_transaction(&buf, thdata);
 
@@ -948,44 +868,6 @@ static void priv_ecdsa_finish(EC_KEY *key)
         dief("failed to parse response");
     }
     iobuf_dispose(&buf);
-}
-
-static int del_ecdsa_key_stub(neverbleed_iobuf_t *buf)
-{
-    size_t key_index;
-    int ret = 0;
-
-    if (iobuf_shift_num(buf, &key_index) != 0) {
-        errno = 0;
-        warnf("%s: failed to parse request", __FUNCTION__);
-        return -1;
-    }
-
-    if (!daemon_vars.keys.ecdsa_keys || key_index >= daemon_vars.keys.ecdsa_slots.reserved_size) {
-        errno = 0;
-        warnf("%s: invalid key index %zu", __FUNCTION__, key_index);
-        goto respond;
-    }
-
-    if (BITCHECK(daemon_vars.keys.ecdsa_slots.bita_avail, key_index)) {
-        warnf("%s: index not in use %zu", __FUNCTION__, key_index);
-        goto respond;
-    }
-
-    pthread_mutex_lock(&daemon_vars.keys.lock);
-    /* set slot as available */
-    BITSET(daemon_vars.keys.ecdsa_slots.bita_avail, key_index);
-    daemon_vars.keys.ecdsa_slots.size--;
-    EC_KEY_free(daemon_vars.keys.ecdsa_keys[key_index]);
-    daemon_vars.keys.ecdsa_keys[key_index] = NULL;
-    pthread_mutex_unlock(&daemon_vars.keys.lock);
-
-    ret = 1;
-
-respond:
-    iobuf_dispose(buf);
-    iobuf_push_num(buf, ret);
-    return 0;
 }
 
 #endif
@@ -1092,7 +974,6 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
 
         rsa = EVP_PKEY_get1_RSA(pkey);
         type = NEVERBLEED_TYPE_RSA;
-        key_index = daemon_set_rsa(rsa);
         RSA_get0_key(rsa, &n, &e, NULL);
         estr = BN_bn2hex(e);
         nstr = BN_bn2hex(n);
@@ -1105,7 +986,6 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
 
         ec_key = (EC_KEY *)EVP_PKEY_get0_EC_KEY(pkey);
         type = NEVERBLEED_TYPE_ECDSA;
-        key_index = daemon_set_ecdsa(ec_key);
         ec_group = EC_KEY_get0_group(ec_key);
         ec_pubkey = EC_KEY_get0_public_key(ec_key);
         ec_pubkeybn = BN_new();
@@ -1125,6 +1005,9 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
         snprintf(errbuf, sizeof(errbuf), "unsupported private key: %d", EVP_PKEY_base_id(pkey));
         goto Respond;
     }
+
+    /* store the key */
+    key_index = daemon_set_pkey(pkey);
 
 Respond:
     iobuf_dispose(buf);
@@ -1324,7 +1207,7 @@ static int priv_rsa_finish(RSA *rsa)
     neverbleed_iobuf_t buf = {NULL};
     size_t ret;
 
-    iobuf_push_str(&buf, "del_rsa_key");
+    iobuf_push_str(&buf, "del_pkey");
     iobuf_push_num(&buf, exdata->key_index);
     iobuf_transaction(&buf, thdata);
 
@@ -1337,7 +1220,7 @@ static int priv_rsa_finish(RSA *rsa)
     return (int)ret;
 }
 
-static int del_rsa_key_stub(neverbleed_iobuf_t *buf)
+static int del_pkey_stub(neverbleed_iobuf_t *buf)
 {
     size_t key_index;
 
@@ -1349,23 +1232,17 @@ static int del_rsa_key_stub(neverbleed_iobuf_t *buf)
         return -1;
     }
 
-    if (!daemon_vars.keys.keys || key_index >= daemon_vars.keys.rsa_slots.reserved_size) {
-        errno = 0;
+    pthread_mutex_lock(&daemon_vars.keys.lock);
+    /* set slot as available */
+    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL) {
+        EVP_PKEY_free(daemon_vars.keys.slots[key_index].pkey);
+        daemon_vars.keys.slots[key_index].pkey = NULL;
+        daemon_vars.keys.slots[key_index].next_empty = daemon_vars.keys.first_empty;
+        daemon_vars.keys.first_empty = key_index;
+    } else {
         warnf("%s: invalid key index %zu", __FUNCTION__, key_index);
         goto respond;
     }
-
-    if (BITCHECK(daemon_vars.keys.rsa_slots.bita_avail, key_index)) {
-        warnf("%s: index not in use %zu", __FUNCTION__, key_index);
-        goto respond;
-    }
-
-    pthread_mutex_lock(&daemon_vars.keys.lock);
-    /* set slot as available */
-    BITSET(daemon_vars.keys.rsa_slots.bita_avail, key_index);
-    daemon_vars.keys.rsa_slots.size--;
-    RSA_free(daemon_vars.keys.keys[key_index]);
-    daemon_vars.keys.keys[key_index] = NULL;
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
     ret = 1;
@@ -1443,15 +1320,12 @@ static void *daemon_conn_thread(void *_sock_fd)
         } else if (strcmp(cmd, "ecdsa_sign") == 0) {
             if (ecdsa_sign_stub(&buf) != 0)
                 break;
-        } else if (strcmp(cmd, "del_ecdsa_key") == 0) {
-            if (del_ecdsa_key_stub(&buf) != 0)
-                break;
 #endif
         } else if (strcmp(cmd, "load_key") == 0) {
             if (load_key_stub(&buf) != 0)
                 break;
-        } else if (strcmp(cmd, "del_rsa_key") == 0) {
-            if (del_rsa_key_stub(&buf) != 0)
+        } else if (strcmp(cmd, "del_pkey") == 0) {
+            if (del_pkey_stub(&buf) != 0)
                 break;
         } else if (strcmp(cmd, "setuidgid") == 0) {
             if (setuidgid_stub(&buf) != 0)

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -479,11 +479,12 @@ static void get_privsep_data(const RSA *rsa, struct st_neverbleed_rsa_exdata_t *
 static struct {
     struct {
         pthread_mutex_t lock;
-        struct {
+        /**
+         * if the slot is use contains a non-NULL key; if not in use, contains the index of the next empty slot or SIZE_MAX if there
+         * are no more empty slots
+         */
+        union {
             EVP_PKEY *pkey;
-            /**
-             * if the slot is currently empty, contains the index of the next empty slot, or SIZE_MAX if there is no more
-             */
             size_t next_empty;
         } *slots;
         size_t num_slots;
@@ -497,7 +498,7 @@ static RSA *daemon_get_rsa(size_t key_index)
     RSA *rsa = NULL;
 
     pthread_mutex_lock(&daemon_vars.keys.lock);
-    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL)
+    if (key_index < daemon_vars.keys.num_slots)
         rsa = EVP_PKEY_get1_RSA(daemon_vars.keys.slots[key_index].pkey);
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
@@ -517,14 +518,15 @@ size_t allocate_slot(void)
         index = daemon_vars.keys.num_slots++;
     }
 
-    daemon_vars.keys.slots[index].pkey = NULL;
-    daemon_vars.keys.slots[index].next_empty = SIZE_MAX;
+    daemon_vars.keys.slots[index].next_empty = SIZE_MAX - 1; /* bogus value to help figure out what happened upon crash */
 
     return index;
 }
 
 static size_t daemon_set_pkey(EVP_PKEY *pkey)
 {
+    assert(pkey != NULL);
+
     pthread_mutex_lock(&daemon_vars.keys.lock);
 
     size_t index = allocate_slot();
@@ -714,7 +716,7 @@ static EC_KEY *daemon_get_ecdsa(size_t key_index)
     EC_KEY *ec_key = NULL;
 
     pthread_mutex_lock(&daemon_vars.keys.lock);
-    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL)
+    if (key_index < daemon_vars.keys.num_slots)
         ec_key = EVP_PKEY_get1_EC_KEY(daemon_vars.keys.slots[key_index].pkey);
     pthread_mutex_unlock(&daemon_vars.keys.lock);
 
@@ -877,7 +879,7 @@ static EVP_PKEY *daemon_get_pkey(size_t key_index)
     EVP_PKEY *pkey = NULL;
 
     pthread_mutex_lock(&daemon_vars.keys.lock);
-    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL) {
+    if (key_index < daemon_vars.keys.num_slots) {
         pkey = daemon_vars.keys.slots[key_index].pkey;
         EVP_PKEY_up_ref(pkey);
     }
@@ -1359,9 +1361,8 @@ static int del_pkey_stub(neverbleed_iobuf_t *buf)
 
     pthread_mutex_lock(&daemon_vars.keys.lock);
     /* set slot as available */
-    if (key_index < daemon_vars.keys.num_slots && daemon_vars.keys.slots[key_index].pkey != NULL) {
+    if (key_index < daemon_vars.keys.num_slots) {
         EVP_PKEY_free(daemon_vars.keys.slots[key_index].pkey);
-        daemon_vars.keys.slots[key_index].pkey = NULL;
         daemon_vars.keys.slots[key_index].next_empty = daemon_vars.keys.first_empty;
         daemon_vars.keys.first_empty = key_index;
     } else {

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -965,9 +965,11 @@ void neverbleed_start_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const 
 
     /* obtain reference */
     switch (EVP_PKEY_base_id(pkey)) {
-    case EVP_PKEY_RSA:
-        get_privsep_data(EVP_PKEY_get0_RSA(pkey), &exdata, &thdata);
-        break;
+    case EVP_PKEY_RSA: {
+        RSA *rsa = EVP_PKEY_get1_RSA(pkey); /* get0 is available not available in OpenSSL 1.0.2 */
+        get_privsep_data(rsa, &exdata, &thdata);
+        RSA_free(rsa);
+    } break;
 #ifdef NEVERBLEED_ECDSA
     case EVP_PKEY_EC:
         ecdsa_get_privsep_data(EVP_PKEY_get0_EC_KEY(pkey), &exdata, &thdata);

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -932,13 +932,16 @@ static int digestsign_stub(neverbleed_iobuf_t *buf)
         if (EVP_PKEY_CTX_set_rsa_mgf1_md(pkey_ctx, md) != 1)
             goto Softfail;
     }
-    if (EVP_DigestSign(mdctx, NULL, &digestlen, signdata, signlen) != 1)
+    /* ED25519 keys can never be loaded, so use the Update -> Final call chain without worrying about backward compatibility */
+    if (EVP_DigestSignUpdate(mdctx, signdata, signlen) != 1)
+        goto Softfail;
+    if (EVP_DigestSignFinal(mdctx, NULL, &digestlen) != 1)
         goto Softfail;
     if (sizeof(digestbuf) < digestlen) {
         warnf("%s: digest unexpectedly long as %zu bytes", __FUNCTION__, digestlen);
         goto Softfail;
     }
-    if (EVP_DigestSign(mdctx, digestbuf, &digestlen, signdata, signlen) != 1)
+    if (EVP_DigestSignFinal(mdctx, digestbuf, &digestlen) != 1)
         goto Softfail;
 
 Respond: /* build response */

--- a/neverbleed.h
+++ b/neverbleed.h
@@ -69,6 +69,15 @@ int neverbleed_load_private_key_file(neverbleed_t *nb, SSL_CTX *ctx, const char 
  */
 int neverbleed_setuidgid(neverbleed_t *nb, const char *user, int change_socket_ownership);
 
+/**
+ * builds a digestsign request
+ */
+void neverbleed_start_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const EVP_MD *md, const void *input, size_t len);
+/**
+ * parses a digestsign response
+ */
+void neverbleed_finish_digestsign(neverbleed_iobuf_t *buf, void **digest, size_t *digest_len);
+
 #if NEVERBLEED_HAS_PTHREAD_SETAFFINITY_NP
 /**
  * set the cpu affinity for the neverbleed thread (returns 0 if successful)


### PR DESCRIPTION
The internals are changed to retain a single vector of EVP_PKEY's rather than having one list of RSA and another of ECDSA.