### PR TITLE
add support for QuickAssist accelerator

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1359,11 +1359,6 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
         goto Respond;
     }
 
-#if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)
-    if (neverbleed_qat && bssl_private_key_method_update(pkey) != 0)
-        dief("failed to set callbacks");
-#endif
-
     switch (EVP_PKEY_base_id(pkey)) {
     case EVP_PKEY_RSA: {
         const BIGNUM *e, *n;

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -532,17 +532,14 @@ struct engine_request {
     neverbleed_iobuf_t *buf;
     int async_fd;
 #ifdef OPENSSL_IS_BORINGSSL
-    enum {
-        ENGINE_REQUEST_TYPE_DIGESTSIGN,
-        ENGINE_REQUEST_TYPE_DECRYPT,
-    } type;
-    union {
-        struct {
-            RSA *rsa;
-            uint8_t padded[512];
-            size_t padded_len;
-            uint8_t signature[512];
-        } digestsign;
+    struct {
+        RSA *rsa;
+        uint8_t output[512];
+        union {
+            struct {
+                uint8_t padded[512];
+            } digestsign;
+        };
     } data;
     async_ctx *async_ctx;
 #else
@@ -1020,6 +1017,23 @@ static EVP_PKEY *daemon_get_pkey(size_t key_index)
 
 #if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)
 
+static struct engine_request *bssl_offload_create_request(neverbleed_iobuf_t *buf, EVP_PKEY *pkey)
+{
+    RSA *_rsa = EVP_PKEY_get1_RSA(pkey);
+
+    struct engine_request *req = malloc(sizeof(*req));
+    if (req == NULL)
+        dief("no memory\n");
+    *req = (struct engine_request){.buf = buf, .async_fd = -1, .async_ctx = bssl_qat_async_start_job(), .data.rsa = _rsa};
+
+    if (req->async_ctx == NULL)
+        dief("failed to initialize async job\n");
+    if (RSA_size(req->data.rsa) > sizeof(req->data.output))
+        dief("RSA key too large\n");
+
+    return req;
+}
+
 static void bssl_offload_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const EVP_MD *md, const void *signdata,
                                     size_t signlen)
 {
@@ -1037,23 +1051,10 @@ static void bssl_offload_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, con
         EVP_MD_CTX_free(mdctx);
     }
 
-    /* instantiate request context */
-    RSA *_rsa = EVP_PKEY_get1_RSA(pkey);
-    struct engine_request *req = malloc(sizeof(*req));
-    if (req == NULL)
-        dief("no memory\n");
-    *req = (struct engine_request){.buf = buf,
-                                   .async_fd = -1,
-                                   .async_ctx = bssl_qat_async_start_job(),
-                                   .type = ENGINE_REQUEST_TYPE_DIGESTSIGN,
-                                   .data.digestsign = {.rsa = _rsa, .padded_len = RSA_size(_rsa)}};
-    if (req->async_ctx == NULL)
-        dief("failed to initialize async job\n");
-    if (sizeof(req->data.digestsign.padded) < req->data.digestsign.padded_len)
-        dief("RSA key too large:%zu\n", req->data.digestsign.padded_len);
+    struct engine_request *req = bssl_offload_create_request(buf, pkey);
 
     /* generate padded octets to be signed */
-    if (!RSA_padding_add_PKCS1_PSS_mgf1(req->data.digestsign.rsa, req->data.digestsign.padded, digest, md, md, -1))
+    if (!RSA_padding_add_PKCS1_PSS_mgf1(req->data.rsa, req->data.digestsign.padded, digest, md, md, -1))
         dief("RSA_paddding_add_PKCS1_PSS_mgf1 failed\n");
 
     OPENSSL_cleanse(digest, sizeof(digest));
@@ -1062,13 +1063,30 @@ static void bssl_offload_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, con
     RSA_METHOD *meth = bssl_engine_get_rsa_method();
     if (meth == NULL)
         dief("failed to obtain QAT RSA method table\n");
-
-    size_t siglen;
-    if (!meth->sign_raw(req->data.digestsign.rsa, &siglen, req->data.digestsign.signature, req->data.digestsign.padded_len,
-                        req->data.digestsign.padded, req->data.digestsign.padded_len, RSA_NO_PADDING))
+    size_t siglen, padded_len = RSA_size(req->data.rsa);
+    if (!meth->sign_raw(req->data.rsa, &siglen, req->data.output, padded_len, req->data.digestsign.padded, padded_len,
+                        RSA_NO_PADDING))
         dief("sign_raw failure\n");
     if (siglen != 0)
-        dief("sign_raw completed synchronously unexpectedly");
+        dief("sign_raw completed synchronously unexpectedly\n");
+
+    buf->processing = 1;
+    register_wait_fd(req);
+}
+
+static void bssl_offload_decrypt(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const void *src, size_t len)
+{
+    struct engine_request *req = bssl_offload_create_request(buf, pkey);
+
+    /* dispatch RSA calculation */
+    RSA_METHOD *meth = bssl_engine_get_rsa_method();
+    if (meth == NULL)
+        dief("failed to obtain QAT RSA method table\n");
+    size_t outlen;
+    if (!meth->decrypt(req->data.rsa, &outlen, req->data.output, len, src, len, RSA_NO_PADDING))
+        dief("RSA decrypt failure\n");
+    if (outlen != 0)
+        dief("RSA decrypt completed synchronously unexppctedly\n");
 
     buf->processing = 1;
     register_wait_fd(req);
@@ -1225,6 +1243,13 @@ static int decrypt_stub(neverbleed_iobuf_t *buf)
     rsa = EVP_PKEY_get1_RSA(pkey); /* get0 is available not available in OpenSSL 1.0.2 */
     assert(rsa != NULL);
     assert(sizeof(decryptbuf) >= RSA_size(rsa));
+
+#if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)
+    if (neverbleed_qat) {
+        bssl_offload_decrypt(buf, pkey, src, srclen);
+        return 0;
+    }
+#endif
 
     if ((decryptlen = RSA_private_decrypt(srclen, src, decryptbuf, rsa, RSA_NO_PADDING)) == -1) {
         errno = 0;
@@ -1648,32 +1673,21 @@ respond:
 
 static int offload_resume(struct engine_request *req)
 {
+    size_t outlen;
+
     if (do_epoll_ctl(conn_ctx.epollfd, EPOLL_CTL_DEL, req->async_fd, NULL) != 0)
         dief("epoll_ctl failed:%d\n", errno);
 
-    switch (req->type) {
-
-    case ENGINE_REQUEST_TYPE_DIGESTSIGN: {
-        size_t siglen;
-        /* get signture */
-        if (bssl_qat_async_ctx_copy_result(req->async_ctx, req->data.digestsign.signature, &siglen,
-                                           sizeof(req->data.digestsign.signature)) != 0)
-            dief("failed to obtain offload result\n");
-        if (siglen > sizeof(req->data.digestsign.signature))
-            dief("RSA signature unexpectedly large\n");
-        /* save the result */
-        iobuf_dispose(req->buf);
-        iobuf_push_bytes(req->buf, req->data.digestsign.signature, siglen);
-        /* cleanup */
-        RSA_free(req->data.digestsign.rsa);
-        req->data.digestsign.rsa = NULL;
-    } break;
-
-    default:
-        dief("FIXME");
-        break;
-
-    }
+    /* get result */
+    if (bssl_qat_async_ctx_copy_result(req->async_ctx, req->data.output, &outlen, sizeof(req->data.output)) != 0)
+        dief("failed to obtain offload result\n");
+    if (outlen > sizeof(req->data.output))
+        dief("RSA output is unexpectedly large\n");
+    /* save the result */
+    iobuf_dispose(req->buf);
+    iobuf_push_bytes(req->buf, req->data.output, outlen);
+    /* cleanup */
+    RSA_free(req->data.rsa);
 
     req->buf->processing = 0;
     free_req(req);

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1989,8 +1989,6 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
         assert(qat != NULL);
         if (!ENGINE_init(qat))
             dief("failed to initialize QAT\n");
-        if (!ENGINE_set_default_RSA(qat))
-            dief("failed to assign RSA operations to QAT\n");
 #else
         dief("QAT is not supported\n");
 #endif

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1730,7 +1730,7 @@ static int offload_start(int (*stub)(neverbleed_iobuf_t *), neverbleed_iobuf_t *
         dief("no memory");
     *req = (struct engine_request){.buf = buf, .async_fd = -1, .stub = stub};
 
-    if ((req->async.ctx =  ASYNC_WAIT_CTX_new()) == NULL)
+    if ((req->async.ctx = ASYNC_WAIT_CTX_new()) == NULL)
         dief("failed to create ASYNC_WAIT_CTX\n");
 
     int ret;

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1672,8 +1672,6 @@ static int wait_for_read(struct conn_ctx *conn_ctx)
         }
     } while (!has_read);
 
-    return 0;
-
 #else
 
     fd_set rfds;
@@ -1683,19 +1681,16 @@ static int wait_for_read(struct conn_ctx *conn_ctx)
 
     while ((ret = select(fd + 1, &rfds, NULL, NULL, NULL)) == -1 && (errno == EAGAIN || errno == EINTR))
         ;
-    if (ret == -1) {
+    if (ret == -1)
         dief("select(2)\n");
-    } else if (ret > 0) {
-        // yield when data is available
-        struct timespec tv = {.tv_nsec = 1};
-        (void)nanosleep(&tv, NULL);
-    } else {
-        dief("unreachable, no timeout configured");
-    }
-
-    return 0;
 
 #endif
+
+    // yield when data is available
+    struct timespec tv = {.tv_nsec = 1};
+    (void)nanosleep(&tv, NULL);
+
+    return 0;
 }
 
 static void *daemon_conn_thread(void *_sock_fd)

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1274,7 +1274,7 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
     }
 
 #ifdef OPENSSL_IS_BORINGSSL
-    if (neverbleed_qat.jobs != 0 && bssl_private_key_method_update(pkey) != 0)
+    if (neverbleed_qat && bssl_private_key_method_update(pkey) != 0)
         dief("failed to set callbacks");
 #endif
 
@@ -1577,7 +1577,7 @@ static int offload_jobfunc(void *_req)
 static int offload_stub(int (*stub)(neverbleed_iobuf_t *), neverbleed_iobuf_t *buf, struct conn_ctx *conn_ctx)
 {
     /* if engine is not used, run the stub synchronously */
-    if (neverbleed_qat.jobs == 0)
+    if (!neverbleed_qat)
         return stub(buf);
 
     buf->processing = 1;
@@ -1849,7 +1849,7 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
     pthread_attr_init(&thattr);
     pthread_attr_setdetachstate(&thattr, 1);
 
-    if (neverbleed_qat.jobs != 0) {
+    if (neverbleed_qat) {
 #ifdef OPENSSL_IS_BORINGSSL
 #ifdef NEVERBLEED_BORINGSSL_USE_QAT
         ENGINE_load_qat();
@@ -2053,4 +2053,4 @@ Fail:
 
 void (*neverbleed_post_fork_cb)(void) = NULL;
 void (*neverbleed_transaction_cb)(neverbleed_iobuf_t *) = NULL;
-struct neverbleed_qat neverbleed_qat = {.jobs = 100};
+int neverbleed_qat = 0;

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1018,7 +1018,7 @@ static EVP_PKEY *daemon_get_pkey(size_t key_index)
     return pkey;
 }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)
 
 static void bssl_offload_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const EVP_MD *md, const void *signdata,
                                     size_t signlen)
@@ -1105,7 +1105,7 @@ static int digestsign_stub(neverbleed_iobuf_t *buf)
         md = NULL;
     }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)
     if (neverbleed_qat && EVP_PKEY_id(pkey) == EVP_PKEY_RSA) {
         bssl_offload_digestsign(buf, pkey, md, signdata, signlen);
         return 0;
@@ -1359,7 +1359,7 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
         goto Respond;
     }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)
     if (neverbleed_qat && bssl_private_key_method_update(pkey) != 0)
         dief("failed to set callbacks");
 #endif
@@ -1971,7 +1971,7 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
     pthread_attr_setdetachstate(&thattr, 1);
 
     if (neverbleed_qat) {
-#if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL) && defined(NEVERBLEED_BORINGSSL_USE_QAT)
+#if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)
         ENGINE_load_qat();
         bssl_qat_set_default_string("RSA");
 #elif USE_OFFLOAD && !defined(OPENSSL_IS_BORINGSSL)

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -2000,7 +2000,7 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
 
     switch (neverbleed_offload) {
     case NEVERBLEED_OFFLOAD_QAT_ON:
-    case NEVERBLEED_OFFLOAD_QAT_AUTO:
+    case NEVERBLEED_OFFLOAD_QAT_AUTO: {
 #if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)
         ENGINE_load_qat();
         bssl_qat_set_default_string("RSA");
@@ -2015,7 +2015,7 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
 #endif
         if (!use_offload && neverbleed_offload == NEVERBLEED_OFFLOAD_QAT_ON)
             dief("use of QAT is forced but unavailable\n");
-        break;
+    } break;
     default:
         break;
     }

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1754,6 +1754,7 @@ static int offload_resume(struct engine_request *req)
  * This function waits for the provided socket to become readable, then calls `nanosleep(1)` before returning.
  * The intention behind sleep is to provide the application to complete its event loop before the neverbleed process starts
  * spending CPU cycles on the time-consuming RSA operation.
+ * In addition, when QAT is used, this function processes completion notifications from QAT and sends the responses.
  */
 static int wait_for_data(int cleanup)
 {

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -514,7 +514,7 @@ static struct {
         size_t first_empty;
     } keys;
     neverbleed_t *nb;
-} daemon_vars = {.keys = {.lock = PTHREAD_MUTEX_INITIALIZER, .first_empty = SIZE_MAX}};
+} daemon_vars = {{.lock = PTHREAD_MUTEX_INITIALIZER, .first_empty = SIZE_MAX}};
 
 static __thread struct {
     int sockfd;

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1991,8 +1991,11 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
         use_offload = ENGINE_QAT_PTR_GET() != NULL;
 #elif USE_OFFLOAD && !defined(OPENSSL_IS_BORINGSSL)
         ENGINE *qat = ENGINE_by_id("qatengine");
-        if (qat != NULL && ENGINE_init(qat))
+        if (qat != NULL && ENGINE_init(qat)) {
+            if (!ENGINE_set_default_RSA(qat))
+                dief("failed to assign RSA operations to QAT\n");
             use_offload = 1;
+        }
 #endif
         if (!use_offload && neverbleed_offload == NEVERBLEED_OFFLOAD_QAT_ON)
             dief("use of QAT is forced but unavailable\n");

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -72,15 +72,19 @@
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
 
+#ifdef __linux
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
+#define USE_OFFLOAD 1
+#endif
 #if defined(OPENSSL_IS_BORINGSSL) && defined(NEVERBLEED_BORINGSSL_USE_QAT)
 #include "qat_bssl.h"
-
 /* the mapping seems to be missing */
 #ifndef ASYNC_WAIT_CTX_get_all_fds
 extern int bssl_async_wait_ctx_get_all_fds(ASYNC_WAIT_CTX *ctx, OSSL_ASYNC_FD *fd, size_t *numfds);
 #define ASYNC_WAIT_CTX_get_all_fds bssl_async_wait_ctx_get_all_fds
 #endif
-
+#define USE_OFFLOAD 1
+#endif
 #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x1010000fL \
@@ -198,18 +202,6 @@ static void set_cloexec(int fd)
     if (fcntl(fd, F_SETFD, O_CLOEXEC) == -1)
         dief("failed to set O_CLOEXEC to fd %d", fd);
 }
-
-#ifdef __linux
-
-static int do_epoll_ctl(int epollfd, int op, int fd, struct epoll_event *event)
-{
-    int ret;
-    while ((ret = epoll_ctl(epollfd, op, fd, event) != 0) && errno == EINTR)
-        ;
-    return ret;
-}
-
-#endif
 
 static int read_nbytes(int fd, void *p, size_t sz)
 {
@@ -507,6 +499,23 @@ static void get_privsep_data(const RSA *rsa, struct st_neverbleed_rsa_exdata_t *
     *thdata = get_thread_data((*exdata)->nb);
 }
 
+static struct {
+    struct {
+        pthread_mutex_t lock;
+        /**
+         * if the slot is use contains a non-NULL key; if not in use, contains the index of the next empty slot or SIZE_MAX if there
+         * are no more empty slots
+         */
+        union {
+            EVP_PKEY *pkey;
+            size_t next_empty;
+        } *slots;
+        size_t num_slots;
+        size_t first_empty;
+    } keys;
+    neverbleed_t *nb;
+} daemon_vars = {.keys = {.lock = PTHREAD_MUTEX_INITIALIZER, .first_empty = SIZE_MAX}};
+
 static __thread struct {
     int sockfd;
 #ifdef __linux
@@ -516,6 +525,8 @@ static __thread struct {
         neverbleed_iobuf_t *first, **next;
     } responses;
 } conn_ctx;
+
+#if USE_OFFLOAD
 
 struct engine_request {
     neverbleed_iobuf_t *buf;
@@ -543,22 +554,24 @@ struct engine_request {
 #endif
 };
 
-static struct {
-    struct {
-        pthread_mutex_t lock;
-        /**
-         * if the slot is use contains a non-NULL key; if not in use, contains the index of the next empty slot or SIZE_MAX if there
-         * are no more empty slots
-         */
-        union {
-            EVP_PKEY *pkey;
-            size_t next_empty;
-        } *slots;
-        size_t num_slots;
-        size_t first_empty;
-    } keys;
-    neverbleed_t *nb;
-} daemon_vars = {.keys = {.lock = PTHREAD_MUTEX_INITIALIZER, .first_empty = SIZE_MAX}};
+static void free_req(struct engine_request *req)
+{
+#ifdef OPENSSL_IS_BORINGSSL
+    bssl_qat_async_finish_job(req->async_ctx);
+#else
+    ASYNC_WAIT_CTX_free(req->async.ctx);
+#endif
+    OPENSSL_cleanse(req, sizeof(*req));
+    free(req);
+}
+
+static int do_epoll_ctl(int epollfd, int op, int fd, struct epoll_event *event)
+{
+    int ret;
+    while ((ret = epoll_ctl(epollfd, op, fd, event) != 0) && errno == EINTR)
+        ;
+    return ret;
+}
 
 static void register_wait_fd(struct engine_request *req)
 {
@@ -577,6 +590,8 @@ static void register_wait_fd(struct engine_request *req)
     if (do_epoll_ctl(conn_ctx.epollfd, EPOLL_CTL_ADD, req->async_fd, &ev) != 0)
         dief("epoll_ctl failed:%d\n", errno);
 }
+
+#endif
 
 static int send_responses(int cleanup)
 {
@@ -1631,20 +1646,10 @@ respond:
     return 0;
 }
 
-static void free_req(struct engine_request *req)
-{
-#ifdef OPENSSL_IS_BORINGSSL
-    bssl_qat_async_finish_job(req->async_ctx);
-#else
-    ASYNC_WAIT_CTX_free(req->async.ctx);
-#endif
-    OPENSSL_cleanse(req, sizeof(*req));
-    free(req);
-}
-
-#ifdef OPENSSL_IS_BORINGSSL
-
 #define offload_start(stub, buf) ((stub)(buf))
+
+#if USE_OFFLOAD
+#ifdef OPENSSL_IS_BORINGSSL
 
 static int offload_resume(struct engine_request *req)
 {
@@ -1689,6 +1694,7 @@ static int offload_jobfunc(void *_req)
     return req->stub(req->buf);
 }
 
+#undef offload_start
 static int offload_start(int (*stub)(neverbleed_iobuf_t *), neverbleed_iobuf_t *buf)
 {
     /* if engine is not used, run the stub synchronously */
@@ -1747,6 +1753,7 @@ static int offload_resume(struct engine_request *req)
 }
 
 #endif
+#endif
 
 /**
  * This function waits for the provided socket to become readable, then calls `nanosleep(1)` before returning.
@@ -1755,7 +1762,7 @@ static int offload_resume(struct engine_request *req)
  */
 static int wait_for_data(int cleanup)
 {
-#ifdef __linux
+#if USE_OFFLOAD
 
     struct epoll_event events[20];
     int has_read = 0, num_events;
@@ -1785,9 +1792,10 @@ static int wait_for_data(int cleanup)
     fd_set rfds;
     int ret;
     FD_ZERO(&rfds);
-    FD_SET(fd, &rfds);
+    if (!cleanup)
+        FD_SET(conn_ctx.sockfd, &rfds);
 
-    while ((ret = select(fd + 1, &rfds, NULL, NULL, NULL)) == -1 && (errno == EAGAIN || errno == EINTR))
+    while ((ret = select(conn_ctx.sockfd + 1, &rfds, NULL, NULL, NULL)) == -1 && (errno == EAGAIN || errno == EINTR))
         ;
     if (ret == -1)
         dief("select(2):%d\n", errno);
@@ -1806,7 +1814,7 @@ static void *daemon_conn_thread(void *_sock_fd)
     conn_ctx.sockfd = (int)((char *)_sock_fd - (char *)NULL);
     conn_ctx.responses.next = &conn_ctx.responses.first;
 
-#ifdef __linux
+#if USE_OFFLOAD
     if ((conn_ctx.epollfd = epoll_create1(EPOLL_CLOEXEC)) == -1)
         dief("epoll_create1 failed:%d\n", errno);
     {
@@ -1963,20 +1971,18 @@ __attribute__((noreturn)) static void daemon_main(int listen_fd, int close_notif
     pthread_attr_setdetachstate(&thattr, 1);
 
     if (neverbleed_qat) {
-#ifdef OPENSSL_IS_BORINGSSL
-#ifdef NEVERBLEED_BORINGSSL_USE_QAT
+#if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL) && defined(NEVERBLEED_BORINGSSL_USE_QAT)
         ENGINE_load_qat();
         bssl_qat_set_default_string("RSA");
-#else
-        dief("QAT is not supported\n");
-#endif
-#else
+#elif USE_OFFLOAD && !defined(OPENSSL_IS_BORINGSSL)
         ENGINE *qat = ENGINE_by_id("qatengine");
         assert(qat != NULL);
         if (!ENGINE_init(qat))
             dief("failed to initialize QAT\n");
         if (!ENGINE_set_default_RSA(qat))
             dief("failed to assign RSA operations to QAT\n");
+#else
+        dief("QAT is not supported\n");
 #endif
     }
 

--- a/neverbleed.h
+++ b/neverbleed.h
@@ -54,6 +54,8 @@ typedef struct st_neverbleed_iobuf_t {
     char *start;
     char *end;
     size_t capacity;
+    struct st_neverbleed_iobuf_t *next;
+    unsigned processing : 1;
 } neverbleed_iobuf_t;
 
 /**
@@ -110,6 +112,13 @@ int neverbleed_get_fd(neverbleed_t *nb);
 static size_t neverbleed_iobuf_size(neverbleed_iobuf_t *buf);
 void neverbleed_transaction_read(neverbleed_t *nb, neverbleed_iobuf_t *buf);
 void neverbleed_transaction_write(neverbleed_t *nb, neverbleed_iobuf_t *buf);
+
+/**
+ * if set to jobs is set to a non-zero value, RSA operations are offloaded to QAT
+ */
+extern struct neverbleed_qat {
+    unsigned jobs;
+} neverbleed_qat;
 
 /* inline function definitions */
 

--- a/neverbleed.h
+++ b/neverbleed.h
@@ -114,11 +114,9 @@ void neverbleed_transaction_read(neverbleed_t *nb, neverbleed_iobuf_t *buf);
 void neverbleed_transaction_write(neverbleed_t *nb, neverbleed_iobuf_t *buf);
 
 /**
- * if set to jobs is set to a non-zero value, RSA operations are offloaded to QAT
+ * if set to a non-zero value, RSA operations are offloaded to QAT
  */
-extern struct neverbleed_qat {
-    unsigned jobs;
-} neverbleed_qat;
+extern int neverbleed_qat;
 
 /* inline function definitions */
 

--- a/neverbleed.h
+++ b/neverbleed.h
@@ -114,9 +114,13 @@ void neverbleed_transaction_read(neverbleed_t *nb, neverbleed_iobuf_t *buf);
 void neverbleed_transaction_write(neverbleed_t *nb, neverbleed_iobuf_t *buf);
 
 /**
- * if set to a non-zero value, RSA operations are offloaded to QAT
+ * if set to a non-zero value, RSA operations are offloaded
  */
-extern int neverbleed_qat;
+extern enum neverbleed_offload_type {
+    NEVERBLEED_OFFLOAD_OFF = 0,
+    NEVERBLEED_OFFLOAD_QAT_ON,
+    NEVERBLEED_OFFLOAD_QAT_AUTO,
+} neverbleed_offload;
 
 /* inline function definitions */
 


### PR DESCRIPTION
This PR adds the capability to offload RSA operations to the Intel QuickAssist accelerator.

ToDo:
* [x] offload RSA decryption on boringssl too (required by legacy TLS/1.2 cipher suites)
* [x] check qat_sw compatibility (confirmed compatibility when OpenSSL is used; cannot build crypto_mb which is a dependency of QAT_engine together with boringssl)
* [x] implemented "auto" mode