### PR TITLE
[boringssl] fix handshake failure when TLS/1.2 client requests PKCS1 signature

### DIFF
--- a/neverbleed.h
+++ b/neverbleed.h
@@ -72,7 +72,8 @@ int neverbleed_setuidgid(neverbleed_t *nb, const char *user, int change_socket_o
 /**
  * builds a digestsign request
  */
-void neverbleed_start_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const EVP_MD *md, const void *input, size_t len);
+void neverbleed_start_digestsign(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const EVP_MD *md, const void *input, size_t len,
+                                 int rsa_pss);
 /**
  * parses a digestsign response
  */


### PR DESCRIPTION
TLS/1.2 requires the use of PKCS1 signatures signing the handshake transcript when the endpoints negotiate to use  PKCS1.

However, we have hard-coded the use of RSA-PSS, leading to incorrect signatures being generated and the handshake failing.

This PR fixes the bug.

It is unlikely there would be many clients that would be affected by this bug. When TLS/1.3 is used, RSA-PSS is used for signing the handshake transcript even when PKCS1 certificates are requested by the client. Also, modern TLS/1.2 clients will support both PKCS1 and RSA-PSS, in which case the server would choose to use RSA-PSS.