### PR TITLE
libressl 3.5 and above have opaque RSA struct

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -52,7 +52,7 @@
 #include <openssl/opensslconf.h>
 #include <openssl/opensslv.h>
 
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) ? LIBRESSL_VERSION_NUMBER >= 0x3050000fL : OPENSSL_VERSION_NUMBER >= 0x1010000fL
 /* RSA_METHOD is opaque, so RSA_meth* are used. */
 #define NEVERBLEED_OPAQUE_RSA_METHOD
 #endif


### PR DESCRIPTION
Based on https://github.com/h2o/h2o/pull/3208.