### PR TITLE
fix small leak and deref in offload_resume

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1836,6 +1836,7 @@ static void *daemon_conn_thread(void *_sock_fd)
 {
     conn_ctx.sockfd = (int)((char *)_sock_fd - (char *)NULL);
     conn_ctx.responses.next = &conn_ctx.responses.first;
+    neverbleed_iobuf_t *buf = NULL;
 
 #if USE_OFFLOAD
     if ((conn_ctx.epollfd = epoll_create1(EPOLL_CLOEXEC)) == -1)
@@ -1862,7 +1863,7 @@ static void *daemon_conn_thread(void *_sock_fd)
     while (1) {
         if (wait_for_data(0) != 0)
             break;
-        neverbleed_iobuf_t *buf = malloc(sizeof(*buf));
+        buf = malloc(sizeof(*buf));
         if (buf == NULL)
             dief("no memory");
         *buf = (neverbleed_iobuf_t){};
@@ -1923,6 +1924,7 @@ static void *daemon_conn_thread(void *_sock_fd)
         }
         /* add response to chain */
         *conn_ctx.responses.next = buf;
+        buf = NULL; /* do not free */
         conn_ctx.responses.next = &buf->next;
         /* send responses if possible */
         if (send_responses(0) != 0)
@@ -1930,6 +1932,7 @@ static void *daemon_conn_thread(void *_sock_fd)
     }
 
 Exit:
+    free(buf);
     /* run the loop while async ops are running */
     while (conn_ctx.responses.first != NULL)
         wait_for_data(1);

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1754,7 +1754,7 @@ static int offload_resume(struct engine_request *req)
 {
     int ret;
 
-    switch (ASYNC_start_job(&req->async.job, req->async.ctx, &ret, offload_jobfunc, req, sizeof(req))) {
+    switch (ASYNC_start_job(&req->async.job, req->async.ctx, &ret, offload_jobfunc, &req, sizeof(req))) {
     case ASYNC_PAUSE:
         /* assume that wait fd is unchanged */
         return 0;


### PR DESCRIPTION
The deref is just picking the change done by @sharksforarms so it matches the other similar calls.

The leak was discussed with @sharksforarms as well. The idea is to free the buffer if it does not get assigned to `*conn_ctx.responses.next`. It seems to me that it's freed correctly once assigned.

@kazuho as requested.