### PR TITLE
fix buf processing in QAT offload fallback mode

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1737,6 +1737,7 @@ static int offload_start(int (*stub)(neverbleed_iobuf_t *), neverbleed_iobuf_t *
         register_wait_fd(req);
         return 0;
     case ASYNC_FINISH: /* completed synchronously */
+        buf->processing = 0;
         break;
     default:
         dief("ASYNC_start_job errored\n");


### PR DESCRIPTION
When `neverbleed-offload: QAT-AUTO` and the Intel QAT driver is installed, but no QAT hardware available, the QAT engine falls back to synchronous openssl functions.

The engine [prints to stderr](https://github.com/intel/QAT_Engine/blob/b2dcde468d51513db5d7aa0fd393f4818d83a65d/e_qat.c#L1068): `QAT_HW device not available & QAT_SW not enabled. Using OpenSSL_SW!`

This fixes a bug where neverbleed thinks the buf is in an async processing state even though it finished synchronously 