### PR TITLE
[openssl] suppress deprecation warnings

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -50,6 +50,9 @@
 #include <priv.h>
 #endif
 
+/* to maximize code-reuse between different stacks, we intentionally use API declared by OpenSSL as legacy */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <openssl/opensslconf.h>
 #include <openssl/opensslv.h>
 


### PR DESCRIPTION
We want to stick to the legacy API as long as we can, as doing so maximizes code-reuse between different TLS stacks.