### PR TITLE
avoid subtracting NULL from NULL, as it is UB in C99

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -262,7 +262,7 @@ static void iobuf_dispose(neverbleed_iobuf_t *buf)
 
 static void iobuf_reserve(neverbleed_iobuf_t *buf, size_t extra)
 {
-    char *n;
+    size_t start_off, end_off;
 
     if (extra <= buf->buf - buf->end + buf->capacity)
         return;
@@ -271,11 +271,20 @@ static void iobuf_reserve(neverbleed_iobuf_t *buf, size_t extra)
         buf->capacity = 4096;
     while (buf->buf - buf->end + buf->capacity < extra)
         buf->capacity *= 2;
-    if ((n = realloc(buf->buf, buf->capacity)) == NULL)
+
+    if (buf->buf != NULL) {
+        start_off = buf->start - buf->buf;
+        end_off = buf->end - buf->buf;
+    } else {
+        /* C99 forbids us doing `buf->start - buf->buf` when both are NULL (undefined behavior) */
+        start_off = 0;
+        end_off = 0;
+    }
+
+    if ((buf->buf = realloc(buf->buf, buf->capacity)) == NULL)
         dief("realloc failed");
-    buf->start = n + (buf->start - buf->buf);
-    buf->end = n + (buf->end - buf->buf);
-    buf->buf = n;
+    buf->start = buf->buf + start_off;
+    buf->end = buf->buf + end_off;
 }
 
 static void iobuf_push_num(neverbleed_iobuf_t *buf, size_t v)


### PR DESCRIPTION
I would be surprised if a C compiler considers NULL - NULL as something else than zero (including UB), but it is UB per-spec.

I've confirmed the change does not cause regression in h2o CI: https://github.com/h2o/h2o/actions/runs/6346506677.

Quoting Section 6.5.6 of C99 (notice it talks only about pointers pointing to an object):
> When two pointers are subtracted, both shall point to elements of the same array object, or one past the last element of the array object; the result is the difference of the subscripts of the two array elements.