### PR TITLE
bssl/QAT: Soft fail on decrypt failure

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -636,7 +636,7 @@ struct engine_request {
 #endif
 };
 
-static void bssl_offload_free_request(struct engine_request *req)
+static void offload_free_request(struct engine_request *req)
 {
 #ifdef OPENSSL_IS_BORINGSSL
     bssl_qat_async_finish_job(req->async_ctx);
@@ -1188,7 +1188,7 @@ static int bssl_offload_decrypt(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const v
     return 1;
 
 Exit:
-    bssl_offload_free_request(req);
+    offload_free_request(req);
     return 0;
 }
 
@@ -1766,7 +1766,7 @@ static int offload_resume(struct engine_request *req)
     iobuf_push_bytes(req->buf, req->data.output, outlen);
 
     req->buf->processing = 0;
-    bssl_offload_free_request(req);
+    offload_free_request(req);
 
     return 0;
 }
@@ -1809,7 +1809,7 @@ static int offload_start(int (*stub)(neverbleed_iobuf_t *), neverbleed_iobuf_t *
         break;
     }
 
-    bssl_offload_free_request(req);
+    offload_free_request(req);
 
     return ret;
 }
@@ -1833,7 +1833,7 @@ static int offload_resume(struct engine_request *req)
 
     /* job done */
     req->buf->processing = 0;
-    bssl_offload_free_request(req);
+    offload_free_request(req);
 
     return ret;
 }

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -640,6 +640,7 @@ static void free_req(struct engine_request *req)
 {
 #ifdef OPENSSL_IS_BORINGSSL
     bssl_qat_async_finish_job(req->async_ctx);
+    RSA_free(req->data.rsa);
 #else
     ASYNC_WAIT_CTX_free(req->async.ctx);
 #endif
@@ -1763,8 +1764,6 @@ static int offload_resume(struct engine_request *req)
     /* save the result */
     iobuf_dispose(req->buf);
     iobuf_push_bytes(req->buf, req->data.output, outlen);
-    /* cleanup */
-    RSA_free(req->data.rsa);
 
     req->buf->processing = 0;
     free_req(req);

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -636,7 +636,7 @@ struct engine_request {
 #endif
 };
 
-static void free_req(struct engine_request *req)
+static void bssl_offload_free_request(struct engine_request *req)
 {
 #ifdef OPENSSL_IS_BORINGSSL
     bssl_qat_async_finish_job(req->async_ctx);
@@ -1188,7 +1188,7 @@ static int bssl_offload_decrypt(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const v
     return 1;
 
 Exit:
-    free_req(req);
+    bssl_offload_free_request(req);
     return 0;
 }
 
@@ -1766,7 +1766,7 @@ static int offload_resume(struct engine_request *req)
     iobuf_push_bytes(req->buf, req->data.output, outlen);
 
     req->buf->processing = 0;
-    free_req(req);
+    bssl_offload_free_request(req);
 
     return 0;
 }
@@ -1809,7 +1809,7 @@ static int offload_start(int (*stub)(neverbleed_iobuf_t *), neverbleed_iobuf_t *
         break;
     }
 
-    free_req(req);
+    bssl_offload_free_request(req);
 
     return ret;
 }
@@ -1833,7 +1833,7 @@ static int offload_resume(struct engine_request *req)
 
     /* job done */
     req->buf->processing = 0;
-    free_req(req);
+    bssl_offload_free_request(req);
 
     return ret;
 }

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1175,7 +1175,7 @@ static int bssl_offload_decrypt(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const v
     if (meth == NULL)
         dief("failed to obtain QAT RSA method table\n");
     size_t outlen;
-    if (!meth->decrypt(req->data.rsa, &outlen, req->data.output, len, src, len, RSA_NO_PADDING))
+    if (!meth->decrypt(req->data.rsa, &outlen, req->data.output, sizeof(req->data.output), src, len, RSA_NO_PADDING)) {
         warnf("RSA decrypt failure\n");
         goto Exit;
     }


### PR DESCRIPTION
This PR proposes to:
- softly fail on decrypt error, as this is user controlled input
- fix for `max_out` parameter when calling decrypt