### PR TITLE
use a configurable amount of worker threads to handle requests

### DIFF
--- a/neverbleed.h
+++ b/neverbleed.h
@@ -33,14 +33,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#if (defined(__linux__) && !defined(__ANDROID__)) || defined(__FreeBSD__) || defined(__NetBSD__)
-#define NEVERBLEED_HAS_PTHREAD_SETAFFINITY_NP 1
-#if defined(__linux__)
-#define NEVERBLEED_CPU_SET_T cpu_set_t
-#else
-#define NEVERBLEED_CPU_SET_T cpuset_t
-#endif
-#endif
 
 #define NEVERBLEED_ERRBUF_SIZE (256)
 #define NEVERBLEED_AUTH_TOKEN_SIZE 32
@@ -62,10 +54,12 @@ typedef struct st_neverbleed_iobuf_t {
     unsigned processing : 1;
 } neverbleed_iobuf_t;
 
+#define NEVERBLEED_MAX_WORKER_THREADS 1024
+
 /**
  * initializes the privilege separation engine (returns 0 if successful)
  */
-int neverbleed_init(neverbleed_t *nb, char *errbuf);
+int neverbleed_init(neverbleed_t *nb, size_t worker_threads, size_t max_events, char *errbuf);
 /**
  * loads a private key file (returns 1 if successful)
  */
@@ -92,13 +86,6 @@ void neverbleed_start_decrypt(neverbleed_iobuf_t *buf, EVP_PKEY *pkey, const voi
  * parses a decrypt response
  */
 void neverbleed_finish_decrypt(neverbleed_iobuf_t *buf, void **digest, size_t *digest_len);
-
-#if NEVERBLEED_HAS_PTHREAD_SETAFFINITY_NP
-/**
- * set the cpu affinity for the neverbleed thread (returns 0 if successful)
- */
-int neverbleed_setaffinity(neverbleed_t *nb, NEVERBLEED_CPU_SET_T *cpuset);
-#endif
 
 /**
  * an optional callback that can be registered by the application for doing stuff immediately after the neverbleed process is being

--- a/test.c
+++ b/test.c
@@ -69,7 +69,7 @@ int dumb_https_server(unsigned short port, SSL_CTX *ctx)
     setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &reuse_flag, sizeof(reuse_flag));
     sin.sin_family = AF_INET;
     sin.sin_addr.s_addr = htonl(0x7f000001);
-    sin.sin_port = htons(8888);
+    sin.sin_port = htons(port);
     if (bind(listen_fd, (void *)&sin, sizeof(sin)) != 0) {
         fprintf(stderr, "bind failed:%s\n", strerror(errno));
         return 111;
@@ -119,7 +119,7 @@ int main(int argc, char **argv)
     SSL_load_error_strings();
     SSL_library_init();
     OpenSSL_add_all_algorithms();
-    if (neverbleed_init(&nb, errbuf) != 0) {
+    if (neverbleed_init(&nb, 3, 5, errbuf) != 0) {
         fprintf(stderr, "openssl_privsep_init: %s\n", errbuf);
         return 111;
     }


### PR DESCRIPTION
instead of having a 1-1 mapping between application thread and neverbleed threads, we can configure a static pool of threads that can handle incoming requests.

Using epoll features, we can have an idle thread handle the next incoming request.

In summary, there is an epoll instance per thread. The client fd is added to each thread's epoll instance with `EPOLLEXCLUSIVE`, so that only a single instance will get woke when the fd is ready.

For offload events, we keep these on the same thread the offload request was started on, I found that offload requests cannot be resumed on a different thread, see https://github.com/intel/QAT_Engine/issues/306

Other:
- removed the ability to set thread affinity (makes less sense when having a thread-pool vs 1-1 mapping with application thread)
- removed yield_on_read as we `poll` to see if the fd is still read-able