### PR TITLE
align and safely enforce the maximum size of RSA keys

### DIFF
--- a/neverbleed.c
+++ b/neverbleed.c
@@ -803,9 +803,7 @@ static int priv_encdec_stub(const char *name,
     }
     if (RSA_size(rsa) > MAX_RSA_BYTES) {
         errno = 0;
-        warnf("%s: RSA key too large (%d bytes)", name, RSA_size(rsa));
-        RSA_free(rsa);
-        return -1;
+        dief("%s: RSA key too large (%d bytes)", name, RSA_size(rsa));
     }
     ret = func((int)flen, from, to, rsa, (int)padding);
     iobuf_dispose(buf);
@@ -887,9 +885,7 @@ static int sign_stub(neverbleed_iobuf_t *buf)
     }
     if (RSA_size(rsa) > MAX_RSA_BYTES) {
         errno = 0;
-        warnf("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
-        RSA_free(rsa);
-        return -1;
+        dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
     }
     ret = RSA_sign((int)type, m, (unsigned)m_len, sigret, &siglen, rsa);
     iobuf_dispose(buf);

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1364,7 +1364,7 @@ static int decrypt_stub(neverbleed_iobuf_t *buf)
 
     rsa = EVP_PKEY_get1_RSA(pkey); /* get0 is available not available in OpenSSL 1.0.2 */
     assert(rsa != NULL);
-    if (RSA_size(rsa) > (int)sizeof(decryptbuf)) {
+    if (RSA_size(rsa) > NEVERBLEED_MAX_RSA_BYTES) {
         errno = 0;
         dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
     }

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -621,10 +621,10 @@ struct engine_request {
 #ifdef OPENSSL_IS_BORINGSSL
     struct {
         RSA *rsa;
-        uint8_t output[512];
+        uint8_t output[MAX_RSA_BYTES];
         union {
             struct {
-                uint8_t padded[512];
+                uint8_t padded[MAX_RSA_BYTES];
             } digestsign;
         };
     } data;
@@ -1119,8 +1119,10 @@ static struct engine_request *bssl_offload_create_request(neverbleed_iobuf_t *bu
 
     if (req->async_ctx == NULL)
         dief("failed to initialize async job\n");
-    if (RSA_size(req->data.rsa) > sizeof(req->data.output))
-        dief("RSA key too large\n");
+    if (RSA_size(req->data.rsa) > MAX_RSA_BYTES) {
+        errno = 0;
+        dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
+    }
 
     return req;
 }

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1121,7 +1121,7 @@ static struct engine_request *bssl_offload_create_request(neverbleed_iobuf_t *bu
         dief("failed to initialize async job\n");
     if (RSA_size(req->data.rsa) > MAX_RSA_BYTES) {
         errno = 0;
-        dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa->data.rsa));
+        dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(req->data.rsa));
     }
 
     return req;

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -799,6 +799,12 @@ static int priv_encdec_stub(const char *name,
         warnf("%s: invalid key index:%zu\n", name, key_index);
         return -1;
     }
+    if (RSA_size(rsa) > (int)sizeof(to)) {
+        errno = 0;
+        warnf("%s: RSA key too large (%d bytes)", name, RSA_size(rsa));
+        RSA_free(rsa);
+        return -1;
+    }
     ret = func((int)flen, from, to, rsa, (int)padding);
     iobuf_dispose(buf);
     RSA_free(rsa);
@@ -875,6 +881,12 @@ static int sign_stub(neverbleed_iobuf_t *buf)
     if ((rsa = daemon_get_rsa(key_index)) == NULL) {
         errno = 0;
         warnf("%s: invalid key index:%zu", __FUNCTION__, key_index);
+        return -1;
+    }
+    if (RSA_size(rsa) > (int)sizeof(sigret)) {
+        errno = 0;
+        warnf("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
+        RSA_free(rsa);
         return -1;
     }
     ret = RSA_sign((int)type, m, (unsigned)m_len, sigret, &siglen, rsa);
@@ -1015,6 +1027,10 @@ static int ecdsa_sign_proxy(int type, const unsigned char *m, int m_len, unsigne
         dief("unexpected non-NULL kinv and rp");
     }
 
+    if (m_len < 0) {
+        errno = 0;
+        dief("%s: negative m_len", __FUNCTION__);
+    }
     iobuf_push_str(&buf, "ecdsa_sign");
     iobuf_push_num(&buf, type);
     iobuf_push_bytes(&buf, m, m_len);
@@ -1346,7 +1362,11 @@ static int decrypt_stub(neverbleed_iobuf_t *buf)
 
     rsa = EVP_PKEY_get1_RSA(pkey); /* get0 is available not available in OpenSSL 1.0.2 */
     assert(rsa != NULL);
-    assert(sizeof(decryptbuf) >= RSA_size(rsa));
+    if (RSA_size(rsa) > (int)sizeof(decryptbuf)) {
+        errno = 0;
+        warnf("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
+        goto Softfail;
+    }
 
 #if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)
     if (use_offload) {

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1520,6 +1520,13 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
         const BIGNUM *e, *n;
 
         rsa = EVP_PKEY_get1_RSA(pkey);
+        /* Reject large key sizes */
+        if (RSA_size(rsa) > 4096) {
+            snprintf(errbuf, sizeof(errbuf),
+                "RSA key too large (%d bytes); neverbleed maximum is 4096 bytes (32768 bits)",
+                RSA_size(rsa));
+            goto Respond;
+        }
         type = NEVERBLEED_TYPE_RSA;
         RSA_get0_key(rsa, &n, &e, NULL);
         estr = BN_bn2hex(e);

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -75,7 +75,9 @@
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
 
-#define MAX_RSA_BYTES 4096
+#ifndef NEVERBLEED_MAX_RSA_BYTES
+#define NEVERBLEED_MAX_RSA_BYTES 4096
+#endif
 
 #ifdef __linux
 #if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
@@ -621,10 +623,10 @@ struct engine_request {
 #ifdef OPENSSL_IS_BORINGSSL
     struct {
         RSA *rsa;
-        uint8_t output[MAX_RSA_BYTES];
+        uint8_t output[NEVERBLEED_MAX_RSA_BYTES];
         union {
             struct {
-                uint8_t padded[MAX_RSA_BYTES];
+                uint8_t padded[NEVERBLEED_MAX_RSA_BYTES];
             } digestsign;
         };
     } data;
@@ -784,7 +786,7 @@ static int priv_encdec_stub(const char *name,
                             int (*func)(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding),
                             neverbleed_iobuf_t *buf)
 {
-    unsigned char *from, to[MAX_RSA_BYTES];
+    unsigned char *from, to[NEVERBLEED_MAX_RSA_BYTES];
     size_t flen;
     size_t key_index, padding;
     RSA *rsa;
@@ -801,7 +803,7 @@ static int priv_encdec_stub(const char *name,
         warnf("%s: invalid key index:%zu\n", name, key_index);
         return -1;
     }
-    if (RSA_size(rsa) > MAX_RSA_BYTES) {
+    if (RSA_size(rsa) > NEVERBLEED_MAX_RSA_BYTES) {
         errno = 0;
         dief("%s: RSA key too large (%d bytes)", name, RSA_size(rsa));
     }
@@ -867,7 +869,7 @@ static int sign_proxy(int type, const unsigned char *m, unsigned int m_len, unsi
 
 static int sign_stub(neverbleed_iobuf_t *buf)
 {
-    unsigned char *m, sigret[MAX_RSA_BYTES];
+    unsigned char *m, sigret[NEVERBLEED_MAX_RSA_BYTES];
     size_t type, m_len, key_index;
     RSA *rsa;
     unsigned siglen = 0;
@@ -883,7 +885,7 @@ static int sign_stub(neverbleed_iobuf_t *buf)
         warnf("%s: invalid key index:%zu", __FUNCTION__, key_index);
         return -1;
     }
-    if (RSA_size(rsa) > MAX_RSA_BYTES) {
+    if (RSA_size(rsa) > NEVERBLEED_MAX_RSA_BYTES) {
         errno = 0;
         dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
     }
@@ -1119,7 +1121,7 @@ static struct engine_request *bssl_offload_create_request(neverbleed_iobuf_t *bu
 
     if (req->async_ctx == NULL)
         dief("failed to initialize async job\n");
-    if (RSA_size(req->data.rsa) > MAX_RSA_BYTES) {
+    if (RSA_size(req->data.rsa) > NEVERBLEED_MAX_RSA_BYTES) {
         errno = 0;
         dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(req->data.rsa));
     }
@@ -1345,7 +1347,7 @@ static int decrypt_stub(neverbleed_iobuf_t *buf)
     void *src;
     EVP_PKEY *pkey;
     RSA *rsa;
-    uint8_t decryptbuf[MAX_RSA_BYTES];
+    uint8_t decryptbuf[NEVERBLEED_MAX_RSA_BYTES];
     int decryptlen;
 
     /* parse input */
@@ -1520,10 +1522,10 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
 
         rsa = EVP_PKEY_get1_RSA(pkey);
         /* Reject large key sizes */
-        if (RSA_size(rsa) > MAX_RSA_BYTES) {
+        if (RSA_size(rsa) > NEVERBLEED_MAX_RSA_BYTES) {
             snprintf(errbuf, sizeof(errbuf),
                 "RSA key too large (%d bytes); neverbleed maximum is %d bytes (%d bits)",
-                RSA_size(rsa), MAX_RSA_BYTES, MAX_RSA_BYTES * 8);
+                RSA_size(rsa), NEVERBLEED_MAX_RSA_BYTES, NEVERBLEED_MAX_RSA_BYTES * 8);
             goto Respond;
         }
         type = NEVERBLEED_TYPE_RSA;

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1343,7 +1343,7 @@ static int decrypt_stub(neverbleed_iobuf_t *buf)
     void *src;
     EVP_PKEY *pkey;
     RSA *rsa;
-    uint8_t decryptbuf[1024];
+    uint8_t decryptbuf[MAX_RSA_BYTES];
     int decryptlen;
 
     /* parse input */
@@ -1362,8 +1362,7 @@ static int decrypt_stub(neverbleed_iobuf_t *buf)
     assert(rsa != NULL);
     if (RSA_size(rsa) > (int)sizeof(decryptbuf)) {
         errno = 0;
-        warnf("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
-        goto Softfail;
+        dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
     }
 
 #if USE_OFFLOAD && defined(OPENSSL_IS_BORINGSSL)

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -1121,7 +1121,7 @@ static struct engine_request *bssl_offload_create_request(neverbleed_iobuf_t *bu
         dief("failed to initialize async job\n");
     if (RSA_size(req->data.rsa) > MAX_RSA_BYTES) {
         errno = 0;
-        dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
+        dief("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa->data.rsa));
     }
 
     return req;

--- a/neverbleed.c
+++ b/neverbleed.c
@@ -75,6 +75,8 @@
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
 
+#define MAX_RSA_BYTES 4096
+
 #ifdef __linux
 #if OPENSSL_VERSION_NUMBER >= 0x1010000fL && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL)
 #define USE_OFFLOAD 1
@@ -782,7 +784,7 @@ static int priv_encdec_stub(const char *name,
                             int (*func)(int flen, const unsigned char *from, unsigned char *to, RSA *rsa, int padding),
                             neverbleed_iobuf_t *buf)
 {
-    unsigned char *from, to[4096];
+    unsigned char *from, to[MAX_RSA_BYTES];
     size_t flen;
     size_t key_index, padding;
     RSA *rsa;
@@ -799,7 +801,7 @@ static int priv_encdec_stub(const char *name,
         warnf("%s: invalid key index:%zu\n", name, key_index);
         return -1;
     }
-    if (RSA_size(rsa) > (int)sizeof(to)) {
+    if (RSA_size(rsa) > MAX_RSA_BYTES) {
         errno = 0;
         warnf("%s: RSA key too large (%d bytes)", name, RSA_size(rsa));
         RSA_free(rsa);
@@ -867,7 +869,7 @@ static int sign_proxy(int type, const unsigned char *m, unsigned int m_len, unsi
 
 static int sign_stub(neverbleed_iobuf_t *buf)
 {
-    unsigned char *m, sigret[4096];
+    unsigned char *m, sigret[MAX_RSA_BYTES];
     size_t type, m_len, key_index;
     RSA *rsa;
     unsigned siglen = 0;
@@ -883,7 +885,7 @@ static int sign_stub(neverbleed_iobuf_t *buf)
         warnf("%s: invalid key index:%zu", __FUNCTION__, key_index);
         return -1;
     }
-    if (RSA_size(rsa) > (int)sizeof(sigret)) {
+    if (RSA_size(rsa) > MAX_RSA_BYTES) {
         errno = 0;
         warnf("%s: RSA key too large (%d bytes)", __FUNCTION__, RSA_size(rsa));
         RSA_free(rsa);
@@ -1521,10 +1523,10 @@ static int load_key_stub(neverbleed_iobuf_t *buf)
 
         rsa = EVP_PKEY_get1_RSA(pkey);
         /* Reject large key sizes */
-        if (RSA_size(rsa) > 4096) {
+        if (RSA_size(rsa) > MAX_RSA_BYTES) {
             snprintf(errbuf, sizeof(errbuf),
-                "RSA key too large (%d bytes); neverbleed maximum is 4096 bytes (32768 bits)",
-                RSA_size(rsa));
+                "RSA key too large (%d bytes); neverbleed maximum is %d bytes (%d bits)",
+                RSA_size(rsa), MAX_RSA_BYTES, MAX_RSA_BYTES * 8);
             goto Respond;
         }
         type = NEVERBLEED_TYPE_RSA;


### PR DESCRIPTION
Builds on top of #72.

This pull request:
* Introduces a constant called NEVERBLEED_RSA_MAX_BYTES, which defaults to 8192.
* Neverbleed refuses to load RSA keys longer than NEVERBLEED_RSA_MAX_BYTES bytes.
* While the other paths have used 8192 as their hard-coded limits, the maximum key size supported by the QAT-backed BoringSSL path was 512 bytes. It is expanded to NEVERBLEED_RSA_MAX_BYTES.
* The RSA operations hard-fail (by calling `dief`) if the key used is longer than NEVERBLEED_RSA_MAX_BYTES. The rationale is that it indicates a logic flaw, as such long keys would never have been loaded.

Remaining question: is 8192 bytes (32768 bits) a good default? 512 bytes (4096 bits) or 1024 bytes (8192 bytes) might be a better choice.